### PR TITLE
Fix broken links to simtack.de->simstack.de

### DIFF
--- a/apps.yaml
+++ b/apps.yaml
@@ -36,7 +36,7 @@ dft-vasp:
     description: |
         The DFT-VASP WaNo implements a wide range of methods available within the VASP code.
     authors: Celso R. C. Rêgo
-    external_url: https://www.simtack.de
+    external_url: https://www.simstack.de
     documentation_url: https://github.com/KIT-WaNos/DFT_VASP/blob/main/README.md
     logo: https://raw.githubusercontent.com/KIT-Workflows/DFT-VASP/main/DFT-VASP.png
     state: development
@@ -50,7 +50,7 @@ format-converter:
     description: |
         This app uses ASE technology to convert a geometry file from x to y format.
     authors: Celso R. C. Rêgo
-    external_url: https://www.simtack.de
+    external_url: https://www.simstack.de
     documentation_url: https://github.com/KIT-Workflows/Format-Converter/blob/master/README.md
     logo: https://raw.githubusercontent.com/KIT-Workflows/Format-Converter/master/Files-Format.png
     state: development
@@ -64,7 +64,7 @@ dft-surface:
     description: |
         This workflow uses the SimStack framework features to perform as an option a single shot DFT calculation of molecules absorbing on a surface.
     authors: Celso R. C. Rêgo
-    external_url: https://www.simtack.de
+    external_url: https://www.simstack.de
     documentation_url: https://github.com/KIT-Workflows/DFT-Surface/blob/main/README.md
     logo: https://raw.githubusercontent.com/KIT-Workflows/DFT-Surface/main/Surface/Surface.png
     state: development

--- a/categories.yaml
+++ b/categories.yaml
@@ -18,7 +18,7 @@ technology-materials-cloud:
   description: The app utilizies the Materials Cloud (https://www.materialscloud.org).
   title: Materials Cloud
 technology-simstack:
-  description: The app utilizes SimStack (https://www.simtack.de).
+  description: The app utilizes SimStack (https://www.simstack.de).
   title: SimStack
 utilities:
   description: Utility apps for everyday tasks.


### PR DESCRIPTION
Hi there, I noticed some broken links and it felt rude not to fix them.

Changes result from `sed -i 's/simtack/simstack/g' *.yaml`, I couldn't spot any other variations on the typo.