### PR TITLE
Fix: Add missing 'metadata.schema.json' to schema configuration.

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -6,6 +6,7 @@ schemas:
   apps: schemas/apps.schema.json
   categories: schemas/categories.schema.json
   apps_meta: schemas/apps_meta.schema.json
+  metadata: schemas/metadata.schema.json
 build:
   html: src/build/html
   static_src: src/static

--- a/src/app_registry/config.py
+++ b/src/app_registry/config.py
@@ -33,6 +33,7 @@ class SchemasConfig:
     apps: str
     categories: str
     apps_meta: str
+    metadata: str
 
 
 @dataclass

--- a/src/app_registry/config.schema.json
+++ b/src/app_registry/config.schema.json
@@ -76,12 +76,16 @@
                 },
                 "apps_meta": {
                     "type": "string"
+                },
+                "metadata": {
+                    "type": "string"
                 }
             },
             "required": [
                 "apps",
                 "apps_meta",
-                "categories"
+                "categories",
+                "metadata"
             ],
             "title": "Schemas"
         }

--- a/src/app_registry/core.py
+++ b/src/app_registry/core.py
@@ -12,6 +12,7 @@ class AppRegistrySchemas:
     apps: dict
     categories: dict
     apps_meta: dict
+    metadata: dict
 
 
 @dataclass

--- a/src/app_registry/web.py
+++ b/src/app_registry/web.py
@@ -112,6 +112,7 @@ def build_from_config(config: Config):
         apps=load_json(Path(config.schemas.apps)),
         categories=load_json(Path(config.schemas.categories)),
         apps_meta=load_json(Path(config.schemas.apps_meta)),
+        metadata=load_json(Path(config.schemas.metadata)),
     )
 
     # Generate the aggregated apps metadata registry.


### PR DESCRIPTION
Adds the `metadata.schema.json` file to the list of schemas.