### PR TITLE
Add app: tomato

### DIFF
--- a/apps.yaml
+++ b/apps.yaml
@@ -249,3 +249,14 @@ yadg:
         - technology-lab
         - stakeholder
         - stakeholder-aurora
+tomato:
+    metadata:
+        title: tomato
+        description: |
+            tomato: au-tomation without the pain. Instrument automation library. Part of the dgbowl suite of tools for digital (electro-)catalysis and battery materials research.
+        authors: Peter Kraus
+        external_url: https://github.com/dgbowl/tomato
+        logo: https://dgbowl.github.io/images/tomato.png
+        state: development
+    categories:
+        - technology-lab

--- a/apps.yaml
+++ b/apps.yaml
@@ -261,3 +261,5 @@ tomato:
     git_url: https://github.com/dgbowl/tomato
     categories:
         - technology-lab
+        - stakeholder
+        - stakeholder-aurora

--- a/apps.yaml
+++ b/apps.yaml
@@ -238,7 +238,7 @@ yadg:
     metadata:
         title: yadg
         description: |
-            yadg: yet another datagram. FAIR data parser for time-resolved experimental data. Part of the dgbowl suite of tools for digital (electro-)catalysis and battery materials research.
+            yadg: yet another datagram. FAIR data parser for time-resolved experimental data. Part of the dgbowl suite of tools for digital (electro-)catalysis and battery materials research, developed at Empa.
         authors: Peter Kraus, Nicolas Vetsch
         documentation_url: https://dgbowl.github.io/yadg
         logo: https://dgbowl.github.io/images/yadg.png
@@ -253,9 +253,9 @@ tomato:
     metadata:
         title: tomato
         description: |
-            tomato: au-tomation without the pain. Instrument automation library. Part of the dgbowl suite of tools for digital (electro-)catalysis and battery materials research.
+            tomato: au-tomation without the pain. Instrument automation library. Part of the dgbowl suite of tools for digital (electro-)catalysis and battery materials research, developed at Empa.
         authors: Peter Kraus
-        documentation_url: https://dgbowl.github.com/tomato
+        documentation_url: https://dgbowl.github.io/tomato
         logo: https://dgbowl.github.io/images/tomato.png
         state: development
     git_url: https://github.com/dgbowl/tomato

--- a/apps.yaml
+++ b/apps.yaml
@@ -255,8 +255,9 @@ tomato:
         description: |
             tomato: au-tomation without the pain. Instrument automation library. Part of the dgbowl suite of tools for digital (electro-)catalysis and battery materials research.
         authors: Peter Kraus
-        external_url: https://github.com/dgbowl/tomato
+        documentation_url: https://dgbowl.github.com/tomato
         logo: https://dgbowl.github.io/images/tomato.png
         state: development
+    git_url: https://github.com/dgbowl/tomato
     categories:
         - technology-lab


### PR DESCRIPTION
Hello everyone,
I would like to register and add our app, `tomato`, to the BIG-MAP Appstore. I'm writing this app as part of the Stakeholder Initiative AiiDA - Aurora between EPFL and Empa, also including @EmpaEconversion. The documentation link is not yet up, it will be populated by the docs once we get closer to release.

@giovannipizzi, @lorisercole, could either of you please have a look at the categories and add AiiDA-specific keys, as well as the appropriate WP key? Once that's done I'll mark this as ready for review/merge.

Cheers!
Peter