### PR TITLE
Add app: Aurora-app

### DIFF
--- a/apps.yaml
+++ b/apps.yaml
@@ -263,3 +263,18 @@ tomato:
         - technology-lab
         - stakeholder
         - stakeholder-aurora
+aurora-app:
+    metadata:
+        title: Aurora-app
+        description: |
+            AiiDAlab app for the Autonomous robotic battery innovation platform (Aurora) BIG-MAP Stakeholder initiative
+        authors: Loris Ercole
+        documentation_url: https://github.com/epfl-theos/aurora-app/blob/main/README.md
+        stage: registered
+    git_url: https://github.com/epfl-theos/aurora-app
+    categories:
+        - technology-aiida
+        - technology-aiidalab
+        - technology-lab
+        - stakeholder
+        - stakeholder-aurora


### PR DESCRIPTION
Hello,
I would like to register and add Aurora-app, to the BIG-MAP Appstore.
This is part of the Aurora Stakeholder Initiative - between EPFL and Empa.

Currently the app is still under active development. I will update the `stage` of this entry once the first beta version is released, in the upcoming days.
The documentation link just points to the readme file, which will be updated as well before releasing the code.