### PR TITLE
DARTS qemu-web-desktop<app-name>

### DIFF
--- a/apps.yaml
+++ b/apps.yaml
@@ -263,3 +263,22 @@ tomato:
         - technology-lab
         - stakeholder
         - stakeholder-aurora
+
+qemu-qeb-desktop:
+    metadata:
+        title: DARTS on-demand computing (qemu-web-desktop)
+        description: |
+            Data Analysis Remote Treatment Service (DARTS) is a remote desktop service that launches virtual machines in the cloud, 
+            and displays them in your browser. These machines can be used for e.g. scientific data treatment.
+            DARTS can be installed and configured in minutes to provide data treatment and simulation environments, 
+            for instance running Quantum-Espresso via ASE.
+        authors: Emmanuel Farhi
+        logo: https://gitlab.com/soleil-data-treatment/soleil-software-projects/remote-desktop/-/raw/master/src/html/desktop/images/darts_logo.png
+        state: stable
+        version: '22.06.10'
+        external_url: https://gitlab.com/soleil-data-treatment/soleil-software-projects/remote-desktop
+    external_url: https://gitlab.com/soleil-data-treatment/soleil-software-projects/remote-desktop
+    categories:
+        - utilities
+        - technology-simstack
+        - data-analysis


### PR DESCRIPTION
Add a cloud service that provides data treatment and simulation environments to run e.g. ASE, QE, etc... Any system can be instantiated as a virtual-machine.

This is a simple infrastructure service that can be installed in a few minutes, and still can distribute the work-load onto a farm of distributed servers. It does not require any OpenStack/K8. The service is highly configurable (server load, authentication, load-leveler, environment configuration scripts, mounts, etc).

It could be useful as a way to make Big-Map APPs available to users, as custom environments. 