### PR TITLE
apps.yaml: add DARTS/qemu-web-desktop

### DIFF
--- a/apps.yaml
+++ b/apps.yaml
@@ -286,7 +286,7 @@ qemu-web-desktop:
             Data Analysis Remote Treatment Service (DARTS) is a remote desktop service that launches virtual machines in the cloud,
             and displays them in your browser. These machines can be used for, e.g., scientific data treatment.
             DARTS can be installed and configured in minutes to provide data treatment and simulation environments,
-            for instance running Quantum-Espresso via ASE.
+            for instance running Quantum ESPRESSO (QE) via the Atomic Simulation Environment (ASE).
         authors: Emmanuel Farhi
         logo: https://gitlab.com/soleil-data-treatment/soleil-software-projects/remote-desktop/-/raw/master/src/html/desktop/images/darts_logo.png
         state: stable


### PR DESCRIPTION
Add a cloud service that provides data treatment and simulation environments to run e.g. ASE, QE, etc... Any system can be instantiated as a virtual-machine.

This is a simple infrastructure service that can be installed in a few minutes, and still can distribute the work-load onto a farm of distributed servers. It does not require any OpenStack/K8. The service is highly configurable (server load, authentication, load-leveler, environment configuration scripts, mounts, etc).

It could be useful as a way to make Big-Map APPs available to users, as custom environments.

The project Git is <https://gitlab.com/soleil-data-treatment/soleil-software-projects/remote-desktop>. We use it at synchrotron SOLEIL for data analysis, as well as simulation.
