### PR TITLE
CI: Build pages on every CI run.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,3 +30,7 @@ jobs:
             - name: Test with pytest
               run: |
                   PYTHONPATH=src/ pytest -v
+
+            - name: Build GH pages (for testing)
+              run: |
+                  python "${GITHUB_WORKSPACE}/src/build.py"


### PR DESCRIPTION
To catch errors that might occur during build but are not caught by the
tests.