### PR TITLE
Update on FullProfAPP status

### DIFF
--- a/apps.yaml
+++ b/apps.yaml
@@ -186,6 +186,7 @@ FullProfAPP:
             An PyQt5 based graphical user interface for the automated analysis of powder X-ray diffraction data based on the refinement engine FullProf.
         authors: Oier Arcelus, Juan Rodriguez-Carvajal, Nebil Ayape Katcho
         external_url: https://code.ill.fr/rodriguez-carvajal/fullprof-app
+        logo: https://code.ill.fr/rodriguez-carvajal/fullprof-app/-/blob/master/src/fpgui/icons/splash.png
         state: development
     categories:
         - data-analysis

--- a/apps.yaml
+++ b/apps.yaml
@@ -183,9 +183,9 @@ FullProfAPP:
     metadata:
         title: FullProfAPP
         description: |
-            An PyQt based graphical user interface for the automated analysis of powder X-ray diffraction data based on the refinement engine FullProf.
+            An PyQt5 based graphical user interface for the automated analysis of powder X-ray diffraction data based on the refinement engine FullProf.
         authors: Oier Arcelus, Juan Rodriguez-Carvajal, Nebil Ayape Katcho
-        external_url: https://github.com/oarcelus/FullProfAPP-beta
+        external_url: https://code.ill.fr/rodriguez-carvajal/fullprof-app
         state: development
     categories:
         - data-analysis


### PR DESCRIPTION
Updated info on FullProfAPP. App's host changed to a public repo in ILL GitLab. Logo provided. Compliant with the new requirements.