### PR TITLE
Reinstate `tomato` and `yadg`

### DIFF
--- a/apps.yaml
+++ b/apps.yaml
@@ -278,7 +278,8 @@ tomato:
         version: '0.2'
     git_url: https://github.com/dgbowl/tomato
     categories:
-        - technology-lab - stakeholder
+        - technology-lab
+        - stakeholder
         - stakeholder-aurora
 aiidalab-aurora:
     metadata:

--- a/apps.yaml
+++ b/apps.yaml
@@ -278,8 +278,7 @@ tomato:
         version: '0.2'
     git_url: https://github.com/dgbowl/tomato
     categories:
-        - technology-lab
-         - stakeholder
+        - technology-lab - stakeholder
         - stakeholder-aurora
 aiidalab-aurora:
     metadata:

--- a/apps.yaml
+++ b/apps.yaml
@@ -251,35 +251,36 @@ HierCVAE:
         state: development
         title: HierCVAE
         external_url: https://biolib.com/ATGGAGCTGTACGTTAAG/HierCVAE/
-# yadg:
-#     metadata:
-#         title: yadg
-#         description: |
-#             yadg: yet another datagram. FAIR data parser for time-resolved experimental data. Part of the dgbowl suite of tools for digital (electro-)catalysis and battery materials research, developed at Empa.
-#         authors: Peter Kraus, Nicolas Vetsch
-#         documentation_url: https://dgbowl.github.io/yadg
-#         logo: https://dgbowl.github.io/images/yadg.png
-#         state: development
-#         version: '4.1'
-#     git_url: https://github.com/dgbowl/yadg
-#     categories:
-#         - technology-lab
-#         - stakeholder
-#         - stakeholder-aurora
-# tomato:
-#     metadata:
-#         title: tomato
-#         description: |
-#             tomato: au-tomation without the pain. Instrument automation library. Part of the dgbowl suite of tools for digital (electro-)catalysis and battery materials research, developed at Empa.
-#         authors: Peter Kraus
-#         documentation_url: https://dgbowl.github.io/tomato
-#         logo: https://dgbowl.github.io/images/tomato.png
-#         state: development
-#     git_url: https://github.com/dgbowl/tomato
-#     categories:
-#         - technology-lab
-#         - stakeholder
-#         - stakeholder-aurora
+yadg:
+    metadata:
+        title: yadg
+        description: |
+            yadg: yet another datagram. FAIR data parser for time-resolved experimental data. Part of the dgbowl suite of tools for digital (electro-)catalysis and battery materials research, developed at Empa.
+        authors: Peter Kraus, Nicolas Vetsch
+        documentation_url: https://dgbowl.github.io/yadg
+        logo: https://dgbowl.github.io/images/yadg.png
+        state: development
+        version: '4.2'
+    git_url: https://github.com/dgbowl/yadg
+    categories:
+        - technology-lab
+        - stakeholder
+        - stakeholder-aurora
+tomato:
+    metadata:
+        title: tomato
+        description: |
+            tomato: au-tomation without the pain. Instrument automation library. Part of the dgbowl suite of tools for digital (electro-)catalysis and battery materials research, developed at Empa.
+        authors: Peter Kraus, Loris Ercole
+        documentation_url: https://dgbowl.github.io/tomato
+        logo: https://dgbowl.github.io/images/tomato.png
+        state: development
+        version: '0.2'
+    git_url: https://github.com/dgbowl/tomato
+    categories:
+        - technology-lab
+         - stakeholder
+        - stakeholder-aurora
 aiidalab-aurora:
     metadata:
         title: Aurora AiiDAlab


### PR DESCRIPTION
Dear maintainers, now that the acknowledgements to BIG-MAP have been merged for both `tomato` and `yadg`, could we please reinstate them to the BIG-MAP app store? Thanks!