### PR TITLE
Add datalab

### DIFF
--- a/apps.yaml
+++ b/apps.yaml
@@ -369,4 +369,5 @@ datalab:
         version: '0.1'
     categories:
         - data-management
-        - open-apis
+        - data-analysis
+        - stakeholder

--- a/apps.yaml
+++ b/apps.yaml
@@ -355,3 +355,18 @@ dft-qe:
         - quantum
         - technology-simstack
         - technology-ase
+
+datalab:
+    metadata:
+        title: Datalab
+        description: |
+            Datalab is a place to store your experimental data and the connections between them.
+        authors: Celso R. C. Rêgo
+        external_url: https://github.com/the-grey-group/datalab
+        documentation_url: https://the-datalab.readthedocs.io
+        logo: https://avatars.githubusercontent.com/u/50706292?s=200&v=4
+        state: development
+        version: '0.1'
+    categories:
+        - data-management
+        - open-apis

--- a/apps.yaml
+++ b/apps.yaml
@@ -361,7 +361,7 @@ datalab:
         title: Datalab
         description: |
             Datalab is a place to store your experimental data and the connections between them.
-        authors: Celso R. C. Rêgo
+        authors: Joshua Bocarsly, Matthew Evans
         external_url: https://github.com/the-grey-group/datalab
         documentation_url: https://the-datalab.readthedocs.io
         logo: https://avatars.githubusercontent.com/u/50706292?s=200&v=4

--- a/categories.yaml
+++ b/categories.yaml
@@ -8,6 +8,9 @@ data-analysis:
 data-visualization:
     description: Apps for visualizing experimental data.
     title: Data Visualization
+data-management:
+    description: Apps for managaing experimental data.
+    title: Data Management
 quantum:
     description: Apps for performing quantum-mechanical calculations.
     title: Quantum


### PR DESCRIPTION
This PR adds the datalab software (external stakeholder project) to the registry.

Took the liberty of adding a data-management category.