### PR TITLE
Added option for default value of affiliations

### DIFF
--- a/apps.yaml
+++ b/apps.yaml
@@ -37,6 +37,7 @@ aiidalab-qe:
     git_url: https://github.com/aiidalab/aiidalab-qe.git
     metadata:
         authors: Xing Wang, Giovanni Pizzi
+        affiliations: PSI, EPFL
         description: |
             Compute band structures and other structure properties with Quantum ESPRESSO
             on the AiiDAlab platform.

--- a/src/app_registry/metadata.py
+++ b/src/app_registry/metadata.py
@@ -18,7 +18,7 @@ def complete_metadata(app_name, metadata, git_url):
 
     metadata.setdefault("state", "registered")
     metadata.setdefault("title", app_name)
-    # metadata.setdefault("affiliations", "not available")
+    metadata.setdefault("affiliations", "not available")
     if git_url:
         metadata.setdefault("authors", util.get_git_author(git_url))
     return metadata

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -53,7 +53,7 @@ def app_metadata(requests_mock, app_logo):
         "title": "Test App",
         "version": "1.0.0",
         "authors": "big-map",
-        # "affiliations": "big-map",
+        "affiliations": "big-map",
         "logo": app_logo.url,
         "state": "development",
     }


### PR DESCRIPTION
Now if affiliations is not provided by app authors the field shows `not available` instead of being blank. Added affiliations for Quantum Espresso AiiDAlab app.