### PR TITLE
Added 2 videos url in the schema

### DIFF
--- a/schemas/metadata.schema.json
+++ b/schemas/metadata.schema.json
@@ -19,6 +19,16 @@
                 "affiliations": {
                     "type": "string"
                 },
+                "videos":{
+                    "installation_url": {
+                        "type": "string",
+                        "format": "uri"
+                    },
+                    "demonstration_url": {
+                        "type": "string",
+                        "format": "uri"
+                    } 
+                },
                 "version": {
                     "type": "string"
                 },


### PR DESCRIPTION
Now the schema can accept 2 video urls for installation and demonstration videos. This is only a change in the schema and is not yet reflected in the main web page.