### PR TITLE
Removed the nested dictionary from metadata

### DIFF
--- a/schemas/metadata.schema.json
+++ b/schemas/metadata.schema.json
@@ -19,15 +19,13 @@
                 "affiliations": {
                     "type": "string"
                 },
-                "videos":{
-                    "installation_url": {
-                        "type": "string",
-                        "format": "uri"
-                    },
-                    "demonstration_url": {
-                        "type": "string",
-                        "format": "uri"
-                    }
+                "video_installation_url": {
+                    "type": "string",
+                    "format": "uri"
+                },
+                "video_demonstration_url": {
+                    "type": "string",
+                    "format": "uri"
                 },
                 "version": {
                     "type": "string"

--- a/src/mod/templates/singlepage.html
+++ b/src/mod/templates/singlepage.html
@@ -84,6 +84,19 @@
     </div>
     {% endif %}
 
+    <h2>Video showcase</h2>
+
+    {% if metadata.video_installation_url %}
+        <p>
+            <strong>Installation</strong>: <a href="{{ metadata.video_installation_url }}" target="_blank">Go to app installation video</a>
+        <p>
+    {% endif %}
+
+    {% if metadata.video_demonstration_url %}
+        <p>
+            <strong>Demonstration</strong>: <a href="{{ metadata.video_demonstration_url }}" target="_blank">Go to app demonstration video</a>
+        <p>
+    {% endif %}
 </main>
 
 {% endblock body %}


### PR DESCRIPTION
Apparently anythin mentioned inside metadata schema needs to be in a single dictionary without nesting, such that all references are of type `metadata.reference_call`. So now the 2 videos should be seperately provided in the yaml file.