### PR TITLE
Update `aiidalab-aurora` repo URL in apps.yaml

### DIFF
--- a/apps.yaml
+++ b/apps.yaml
@@ -372,7 +372,7 @@ aiidalab-aurora:
         state: registered
         video_installation_url: https://drive.google.com/file/d/1JI6kJq100u1RecCum0BHoz_wiBj8HWay/preview
         video_demonstration_url: https://drive.google.com/file/d/183qPIfW9gQSKq5IU8WmfyVK5o1BcQ4A_/preview
-    git_url: https://github.com/epfl-theos/aiidalab-aurora
+    git_url: https://github.com/EmpaEconversion/aiidalab-aurora
     categories:
         - technology-aiida
         - technology-aiidalab


### PR DESCRIPTION
The `aiidalab-aurora` repo has been moved to the EmpaEconversion organization. This proposed change reflects the move by updating the `git_url` field of the entry.